### PR TITLE
Add Nvoicepay logs to datadog

### DIFF
--- a/23jkGNEEI97DHhes4.yaml
+++ b/23jkGNEEI97DHhes4.yaml
@@ -188,3 +188,11 @@ logs:
     source: ProdEarlyAPI
     sourcecategory: sourcecode
     tags: nginx-access
+  -
+    type: file
+    path: /var/www/html/app/logs/prod/json_formatted.log
+    service: json_formatted
+    source: ProdEarlyAPI
+    sourcecategory: sourcecode
+    tags: json_formatted
+


### PR DESCRIPTION
Log monitoring for Nvoicepay for Datadog (change has been applied on running nodes already)